### PR TITLE
Update/community files

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,26 @@
+# Directories
+/.git
+/.github
+/.wordpress-org
+/bin
+/tests
+
+# Files
+.distignore
+.editorconfig
+.eslintignore
+.eslintrc
+.gitignore
+.npmrc
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+composer.json
+composer.lock
+CONTRIBUTING.md
+CREDITS.md
+LICENSE.md
+package-lock.json
+package.json
+phpcs.xml
+phpunit.xml
+README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/), and will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] - TBD
+
+## [1.0.0] - TBD
+### Added
+- Initial private release of Gutenbridge.
+
+[Unreleased]: https://github.com/10up/gutenbridge/compare/trunk...develop
+[1.0.0]: https://github.com/10up/gutenbridge/tree/commit-hash-here

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at opensource@10up.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing and Maintaining
+
+First, thank you for taking the time to contribute!
+
+The following is a set of guidelines for contributors as well as information and instructions around our maintenance process.  The two are closely tied together in terms of how we all work together and set expectations, so while you may not need to know everything in here to submit an issue or pull request, it's best to keep them in the same document.
+
+## Ways to contribute
+
+Contributing isn't just writing code - it's anything that improves the project.  All contributions for Gutenbridge are managed right here on GitHub. Here are some ways you can help:
+
+### Reporting bugs
+
+If you're running into an issue with the plugin, please take a look through [existing issues](https://github.com/10up/gutenbridge/issues) and [open a new one](https://github.com/10up/gutenbridge/issues/new) if needed.  If you're able, include steps to reproduce, environment information, and screenshots/screencasts as relevant.
+
+### Suggesting enhancements
+
+New features and enhancements are also managed via [issues](https://github.com/10up/gutenbridge/issues).
+
+### Pull requests
+
+Pull requests represent a proposed solution to a specified problem.  They should always reference an issue that describes the problem and contains discussion about the problem itself.  Discussion on pull requests should be limited to the pull request itself, i.e. code review.
+
+For more on how 10up writes and manages code, check out our [10up Engineering Best Practices](https://10up.github.io/Engineering-Best-Practices/).
+
+## Workflow
+
+The `develop` branch is the development branch which means it contains the next version to be released.  `trunk` contains the latest released version as reflected in the WordPress.org plugin repository.  Always work on the `develop` branch and open up PRs against `develop`.
+
+## Release instructions
+
+1. Branch: Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
+2. Version bump: Bump the version number in `gutenbridge.php`, `readme.txt`, and `package.json` if it does not already reflect the version being released.  Update both the plugin "Version:" property in `gutenbridge.php` and the plugin `$plugin_version` constant in `config.php`.
+3. Changelog: Add/update the changelog in `CHANGELOG.md` and `readme.txt`.
+4. Props: update `CREDITS.md` with any new contributors, confirm maintainers are accurate.
+5. New files: Check to be sure any new files/paths that are unnecessary in the production version are included in `.distignore`.
+6. Readme updates: Make any other readme changes as necessary. `README.md` is geared toward GitHub and `readme.txt` contains WordPress.org-specific content.  The two are slightly different.
+7. Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then do the same for `develop` into `trunk` (`git checkout trunk && git merge --no-ff develop`). `trunk` contains the stable development version.
+8. Push: Push your `trunk` branch to GitHub (e.g. `git push origin trunk`).
+9. [Wait for build](https://xkcd.com/303/): Head to the [Actions](https://github.com/10up/gutenbridge/actions) tab in the repo and wait for it to finish if it hasn't already. If it doesn't succeed, figure out why and start over.
+10. Release: Create a [new release](https://github.com/10up/gutenbridge/releases/new), naming the tag and the release with the new version number, and targeting the `trunk` branch. Paste the changelog from `CHANGELOG.md` into the body of the release and include a link to the [closed issues on the milestone](https://github.com/10up/gutenbridge/milestone/#?closed=1).
+11. SVN: Wait for the [GitHub Action](https://github.com/10up/gutenbridge/actions) to finish deploying to the WordPress.org repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
+12. Check WordPress.org: Ensure that the changes are live on https://wordpress.org/plugins/gutenbridge/. This may take a few minutes.
+13. Close the milestone: Edit the [X.Y.Z milestone](https://github.com/10up/gutenbridge/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close the milestone.
+14. Punt incomplete items: If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X+1.0.0`, `X.Y+1.0`, `X.Y.Z+1`, or `Future Release`

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,19 @@
+The following acknowledges the Maintainers for this repository, those who have Contributed to this repository (via bug reports, code, design, ideas, project management, translation, testing, etc.), and any Libraries utilized.
+
+## Maintainers
+
+The following individuals are responsible for curating the list of issues, responding to pull requests, and ensuring regular releases happen.
+
+[Darshan Sawardekar (@dsawardekar)](https://github.com/dsawardekar), [Taylor Lovett (@tlovett1)](https://github.com/tlovett1), [Jeffrey Paul](https://github.com/jeffpaul)
+
+## Contributors
+
+Thank you to all the people who have already contributed to this repository via bug reports, code, design, ideas, project management, translation, testing, etc.
+
+[Darshan Sawardekar (@dsawardekar)](https://github.com/dsawardekar), [Taylor Lovett (@tlovett1)](https://github.com/tlovett1), [Jeffrey Paul](https://github.com/jeffpaul).
+
+## Libraries
+
+The following software libraries are utilized in this repository.
+
+n/a.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Gutenbridge
 
+>  Convert classic editor posts to Gutenberg on the fly.
+
+[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/gutenbridge.svg)](https://github.com/10up/gutenbridge/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.5%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/gutenbridge.svg)](https://github.com/10up/gutenbridge/blob/develop/LICENSE.md)
+
+## Overview
+
 Gutenbridge is a WordPress plugin that transforms classic editor content to [Gutenberg](https://wordpress.org/gutenberg/) blocks on the fly. After installing Gutenberg or upgrading to WordPress 5.0+, your content will be showing in "Classic Editor Blocks". While these blocks are completely functional and will display fine on the front of your website, they do not empower editors to fully make use of the Gutenberg experience.  In order to do so, your classic editor posts need to be converted to Gutenberg blocks. This plugin does that for you "on the fly". When an editor goes to edit a classic post, the content will be parsed into blocks. When the editor saves the post, the new structure will be saved into the database. This strategy reduces risk as you are only altering database values for content that needs to be changed.
 
 ## Requirements
@@ -7,13 +13,13 @@ Gutenbridge is a WordPress plugin that transforms classic editor content to [Gut
 * PHP 7.0+
 * WordPress 5.4+
 
-## Install
+## Installation
 
 1. Clone the repository into your `/plugins` directory.
 2. Inside the repository directory, run `npm install` and then `npm build`.
 3. Inside the repository directory, run `composer install`.
 
-## FAQ
+## Frequently Asked Questions
 
 ### How Do I Know It's Working?
 
@@ -23,16 +29,20 @@ Find a classic editor in the post, try to navigate away from the page. You will 
 
 By default it will not.
 
-## Issues
-
-If you identify any errors or have an idea for improving the plugin, please [open an issue](https://github.com/10up/gutenbridge/issues?state=open). We're excited to see what the community thinks of this project, and we would love your input!
-
 ## Support Level
 
 **Active:** 10up is actively working on this, and we expect to continue work for the foreseeable future including keeping tested up to the most recent version of WordPress.  Bug reports, feature requests, questions, and pull requests are welcome.
 
+## Changelog
+
+A complete listing of all notable changes to Gutenbridge are documented in [CHANGELOG.md](https://github.com/10up/gutenbridge/blob/develop/CHANGELOG.md).
+
+## Contributing
+
+Please read [CODE_OF_CONDUCT.md](https://github.com/10up/gutenbridge/blob/develop/CODE_OF_CONDUCT.md) for details on our code of conduct, [CONTRIBUTING.md](https://github.com/10up/gutenbridge/blob/develop/CONTRIBUTING.md) for details on the process for submitting pull requests to us, and [CREDITS.md](https://github.com/10up/gutenbridge/blob/develop/CREDITS.md) for a listing of maintainers of, contributors to, and libraries used by Gutenbridge.
+
 ## Like what you see?
 
 <p align="center">
-<a href="http://10up.com/contact/"><img src="https://10updotcom-wpengine.s3.amazonaws.com/uploads/2016/10/10up-Github-Banner.png" width="850"></a>
+<a href="http://10up.com/contact/"><img src="https://10up.com/uploads/2016/10/10up-Github-Banner.png" width="850"></a>
 </p>

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "10up/gutenbridge",
   "description": "Gutenbridge is a WordPress plugin that transforms classic editor content to Gutenberg blocks on the fly.",
   "type": "wordpress-plugin",
+  "license": "GPLv2 or later",
   "authors": [
     {
       "name": "10up",

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,13 @@
 {
   "name": "10up/gutenbridge",
-  "description": "Gutenberg Migration Bridge",
+  "description": "Gutenbridge is a WordPress plugin that transforms classic editor content to Gutenberg blocks on the fly.",
+  "type": "wordpress-plugin",
   "authors": [
     {
-      "name": "Darshan Sawardekar",
-      "email": "darshan@10up.com"
+      "name": "10up",
+			"email": "opensource@10up.com",
+			"homepage": "https://10up.com",
+			"role": "Developer"
     }
   ],
   "require": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "gutenbridge",
   "version": "1.0.0",
-  "description": "Gutenbridge",
+  "description": "Gutenbridge is a WordPress plugin that transforms classic editor content to Gutenberg blocks on the fly.",
   "author": {
-    "name": "Darshan Sawardekar",
-    "email": "darshan@10up.com",
+    "name": "10up",
+    "email": "opensource@10up.com",
     "url": "https://10up.com",
     "role": "developer"
   },
+  "license": "GPL-2.0-only",
   "scripts": {
     "test": "phpunit",
     "start": "composer install && npm install && npm run build",
@@ -34,7 +35,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://gitlab.com/10up-internal/gutenbridge"
+    "url": "https://github.com/10up/gutenbridge"
   },
   "devDependencies": {
     "@10up/eslint-config": "^2.1.1",

--- a/plugin.php
+++ b/plugin.php
@@ -1,14 +1,18 @@
 <?php
 /**
- * Plugin Name: Gutenbridge
- * Description: Gutenberg Migration Support
- * Version:     1.0
- * Author:      Darshan Sawardekar, Taylor Lovett, 10up
- * Author URI:  https://10up.com
- * Text Domain: gutenbridge
- * Domain Path: /languages
+ * Plugin Name:       Gutenbridge
+ * Plugin URI:        https://github.com/10up/gutenbridge
+ * Description:       Gutenberg Migration Support
+ * Version:           1.0.0
+ * Requires at least: 5.4
+ * Requires PHP:      7.0
+ * Author:            10up
+ * Author URI:        https://10up.com
+ * License:           GPLv2 or later
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       gutenbridge
  *
- * @package Gutenbridge
+ * @package           Gutenbridge
  */
 
 /**
@@ -125,4 +129,3 @@ function gutenbridge_autoload_notice() {
 }
 
 gutenbridge_autorun();
-

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,12 @@
 === Gutenbridge ===
-Contributors:      dsawardekar, tlovett1, 10up
-Tags: gutenberg, block, block migration, gutenberg migration, gutenberg conversion
+Contributors:      10up, dsawardekar, tlovett1
+Tags:              gutenberg, block, block migration, gutenberg migration, gutenberg conversion
 Requires at least: 5.4
 Tested up to:      5.5
-Stable tag:        1.0
+Requires PHP:      7.0
+Stable tag:        1.0.0
+License:           GPLv2 or later
+License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
 Gutenbridge is a WordPress plugin that transforms classic editor content to Gutenberg blocks on the fly.
 
@@ -20,11 +23,11 @@ Gutenbridge is a WordPress plugin that transforms classic editor content to [Gut
 
 == Frequently Asked Questions ==
 
-__How Do I Know It's Working?__
+= How Do I Know It's Working? =
 
 Find a classic editor in the post, try to navigate away from the page. You will get an error saying your changes will be discarded. This is because Gutenbridge converted your content to blocks on the fly and those changes will be saved when you update the post.
 
-__Will Gutenbridge Handle My Custom Blocks?__
+= Will Gutenbridge Handle My Custom Blocks? =
 
 By default it will not.
 
@@ -33,5 +36,5 @@ By default it will not.
 
 == Changelog ==
 
-= 1.0 =
-* First release
+= 1.0.0 =
+* Initial private release of Gutenbridge.


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR adds the standard set of GitHub community files, updates WordPress.org requirements to the main plugin file and readme.txt, as well as updated composer.json and package.json standard items.

One item I didn't handle in this PR, but can update the branch to include, is renaming `plugin.php` to `gutenbridge.php` as well as any references from `plugin.php` to `gutenbridge.php`.  If that renaming is desired, then I can work to make those changes in this PR as well.  Just let me know... thanks!

### Alternate Designs

n/a

### Benefits

Ensures the plugin follows our [Open Source Best Practices](https://10up.github.io/Open-Source-Best-Practices/).

### Possible Drawbacks

none identified

### Verification Process

Manually verified via the GitHub Desktop UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
```
### Added
- Documentation updates (props @jeffpaul)
```