### PR TITLE
Don't modify edit links if previous request had the classic editor query param

### DIFF
--- a/includes/ConvertToBlocks/RevisionSupport.php
+++ b/includes/ConvertToBlocks/RevisionSupport.php
@@ -27,7 +27,6 @@ class RevisionSupport {
 	 */
 	public function register() {
 		add_action( 'wp_redirect', [ $this, 'update_redirect' ], 10, 2 );
-		add_filter( 'get_edit_post_link', [ $this, 'update_edit_post_link' ] );
 		add_filter( 'wp_prepare_revision_for_js', [ $this, 'update_revision_js' ], 10, 3 );
 	}
 
@@ -51,20 +50,6 @@ class RevisionSupport {
 		}
 
 		return $location;
-	}
-
-	/**
-	 * Updates post link if originating from a classic editor page
-	 *
-	 * @param string $url The post url
-	 * @return string
-	 */
-	public function update_edit_post_link( $url ) {
-		if ( $this->container->is_classic_post_referer() ) {
-			return add_query_arg( [ 'classic' => 1 ], $url );
-		}
-
-		return $url;
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change

Currently, if you click to edit a post in the classic editor and then go back to the edit post list, the next post you click on will automatically open in the classic editor, no matter what edit option you choose.

This PR removes the code that is responsible for this, as it's not ideal to force the classic editor when a user hasn't actually selected that option.

### Alternate Designs

None

### Benefits

Each post you edit will open the right editing experience, irregardless of any previously selected choice

### Possible Drawbacks

None

### Verification Process

1. Click to edit a post in the classic editor
2. Go back to the post list view
3. Click the regular edit button on a different post
4. Note that it should open in the block editor

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

### Applicable Issues

Closes #9 