### PR TITLE
Fix: Issue 21

### DIFF
--- a/includes/ConvertToBlocks/Plugin.php
+++ b/includes/ConvertToBlocks/Plugin.php
@@ -241,6 +241,11 @@ class Plugin {
 		}
 
 		$block_editor = get_post_meta( $post_id, 'block_editor', true );
+
+		if ( ! $block_editor ) {
+			$block_editor = has_blocks( get_the_content( $post_id ) );
+		}
+
 		$block_editor = filter_var( $block_editor, FILTER_VALIDATE_BOOLEAN );
 		$block_editor = apply_filters( 'convert_to_blocks_is_block_editor_post', $block_editor, $post_id );
 

--- a/includes/ConvertToBlocks/Plugin.php
+++ b/includes/ConvertToBlocks/Plugin.php
@@ -243,7 +243,7 @@ class Plugin {
 		$block_editor = get_post_meta( $post_id, 'block_editor', true );
 
 		if ( ! $block_editor ) {
-			$block_editor = has_blocks( get_the_content( $post_id ) );
+			$block_editor = has_blocks( $post_id );
 		}
 
 		$block_editor = filter_var( $block_editor, FILTER_VALIDATE_BOOLEAN );


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR implements a fix for https://github.com/10up/convert-to-blocks/issues/21 by adding a `has_blocks()` conditional on the post content to check if a post does in fact contain blocks. This conditional is added to the main `is_block_editor_post()` method and runs **after** and **only** if the `get_post_meta()` call returns `false`.

The reason for the issue in the first place is coming from the addition of the `use_block_editor_for_post` filter in the `ClassicEditorSupport.php` file.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

An alternative solution would be to rewrite the method executed with the `use_block_editor_for_post` filter to verify if a post has blocks earlier in the lifecycle. I chose the solution proposed because returning `false` from the `use_block_editor_for_post` filter would prevent posts from loading the Gutenberg Editor entirely if no blocks were present in the post content, which would make the other methods such as `post_supports_convert_to_blocks()` return `false` as well.

### Benefits

<!-- What benefits will be realized by the code change? -->
The post list in the editor will no longer display the incorrect editor type in the Editor column. The current version **always** displays "Classic Editor" even if the post was created in Gutenberg to begin with.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
This may not actually be an issue, but it's possible when a user is requesting a large amount of posts in the dashboard post list (i.e. 100 per page) there could end up being some performance issues because the `has_blocks()` method runs the `get_post()` method inside it and checks the `post_content` parameter for Gutenberg comments. This is the validation process if a post contains Gutenberg Blocks from the Block Editor.

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->
- Created several posts in both the Block Editor and Classic Editor and verified they were showing the correct labels in the dashboard Post List.
-- All posts contained the correct "Classic Editor"  or "Block Editor" labels as expected.
- Click into each newly created post and ensure the editor loads as expected.
-- When clicking on the Post Titles, all posts loaded the Gutenberg Editor whether it was originally created in it or not.
-- I had to actually click the "Edit (Classic Editor)" button to open posts created in the Classic Editor, in the Classic Editor.
-- **NOTE:** This may be another issue uncovered. If posts were originally created in the Classic Editor and not yet converted, should they always open in the Classic Editor by default instead of the user needing to click the _"Edit (Classic Editor)"_ link?

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
https://github.com/10up/convert-to-blocks/issues/21

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

Added additional `has_blocks()` conditional to verify if post content does in fact contain blocks from the Gutenberg Editor.
