### PR TITLE
Adds timeout to delay initialization until Gutenberg is ready.

### DIFF
--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -30,7 +30,10 @@ class ConnectToBlocksEditorSupport {
 	 */
 	didBlockEditorLoad() {
 		const transformer = new ClassicBlockTransformer();
-		transformer.execute();
+
+		setTimeout(function () {
+			transformer.execute();
+		}, 100);
 	}
 }
 

--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -29,11 +29,19 @@ class ConnectToBlocksEditorSupport {
 	 * Executes the classic to block transform.
 	 */
 	didBlockEditorLoad() {
+		const { registerPlugin } = window.wp.plugins;
 		const transformer = new ClassicBlockTransformer();
 
-		setTimeout(function () {
-			transformer.execute();
-		}, 100);
+		if (!registerPlugin) {
+			return;
+		}
+
+		registerPlugin('convert-to-blocks', {
+			render: () => {
+				transformer.execute();
+				return null;
+			},
+		});
 	}
 }
 

--- a/assets/js/editor/transform/ClassicBlockTransformer.js
+++ b/assets/js/editor/transform/ClassicBlockTransformer.js
@@ -10,12 +10,20 @@ class ClassicBlockTransformer {
 	 */
 	constructor() {
 		this.wp = window.wp;
+		this.executed = false;
 	}
 
 	/**
 	 * Runs the Classic to Gutenberg Block transform on the current document.
 	 */
 	execute() {
+		// only execute once per page on load
+		if (this.executed) {
+			return;
+		}
+
+		this.executed = true;
+
 		const coreEditor = this.wp.data.select('core/block-editor');
 		const blocks = coreEditor.getBlocks();
 

--- a/assets/js/editor/transform/ClassicBlockTransformer.js
+++ b/assets/js/editor/transform/ClassicBlockTransformer.js
@@ -10,20 +10,12 @@ class ClassicBlockTransformer {
 	 */
 	constructor() {
 		this.wp = window.wp;
-		this.executed = false;
 	}
 
 	/**
 	 * Runs the Classic to Gutenberg Block transform on the current document.
 	 */
 	execute() {
-		// only execute once per page on load
-		if (this.executed) {
-			return;
-		}
-
-		this.executed = true;
-
 		const coreEditor = this.wp.data.select('core/block-editor');
 		const blocks = coreEditor.getBlocks();
 


### PR DESCRIPTION
### Requirements

The Convert To Blocks JS initialization fails in WordPress 5.6. The `core/block-editor` returns an empty array of blocks. We need to delay the initialization until Gutenberg returns blocks data.

### Description of the Change

I added a 100 ms delay before the transformer initializes. This is an interim workaround until we can figure out why Gutenberg returns an empty list of blocks on load.

### Alternate Designs

I tried out using [wp.domReady](https://developer.wordpress.org/block-editor/packages/packages-dom-ready/) without luck. Gutenberg doesn't not appear to have a way to signal a `ready` event to external plugins / libraries.

### Benefits

I tested the fix on various classic HTML posts, and was able to verify that they were converted to blocks on load.

### Possible Drawbacks

The timeout solution is a workaround until we can use a native `ready` event within Gutenberg.

### Verification Process

1. I installed WordPress RC3 via WP CLI.
2. I installed test content from wptest.io.
3. I opened different posts in the Block Editor and confirmed that they were converted to Gutenberg blocks.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

### Applicable Issues

https://github.com/10up/convert-to-blocks/issues/23

### Changelog Entry

Added small delay to initialization to wait for Gutenberg to initialize for compatibility with WordPress 5.6.
