### PR TITLE
Try fixing our lint workflow by using the correct PHP version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Set PHP version
+      uses: shivammathur/setup-php@v1
+      with:
+        php-version: '7.2'
+        coverage: none
     - name: composer install
       run: composer install
     - name: PHPCS check


### PR DESCRIPTION
### Description of the Change

Our current lint workflow is failing because it is using the wrong PHP version. This PR attempts to downgrade PHP during this workflow to fix this issue.

### Alternate Designs

None

### Benefits

Linting workflow will run

### Possible Drawbacks

None