### PR TITLE
Add post type argument to post_type_supports_convert_to_blocks filter

### DIFF
--- a/includes/ConvertToBlocks/Plugin.php
+++ b/includes/ConvertToBlocks/Plugin.php
@@ -204,7 +204,7 @@ class Plugin {
 			$supports = true;
 		}
 
-		$supports = apply_filters( 'post_type_supports_convert_to_blocks', $supports );
+		$supports = apply_filters( 'post_type_supports_convert_to_blocks', $supports, $post_type );
 
 		return $supports;
 	}


### PR DESCRIPTION
Simple PR to fix the `post_type_supports_convert_to_blocks` filter adding the `$post_type` argument.