### PR TITLE
Add values in hierarchical post columns

### DIFF
--- a/includes/ConvertToBlocks/PostTypeColumnSupport.php
+++ b/includes/ConvertToBlocks/PostTypeColumnSupport.php
@@ -33,6 +33,7 @@ class PostTypeColumnSupport {
 				continue;
 			}
 			add_filter( "manage_{$post_type}_posts_columns", [ $this, 'update_post_columns' ], 10000 );
+			add_action( "manage_{$post_type}_pages_custom_column", [ $this, 'update_post_column_value' ], 10, 2 );
 			add_action( "manage_{$post_type}_posts_custom_column", [ $this, 'update_post_column_value' ], 10, 2 );
 		}
 	}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Hi, thanks for working with this plugin. I have added the necessary hook to see the values of the current editor in the column of the hierarchical posts. Reference: https://developer.wordpress.org/reference/hooks/manage_pages_custom_column/

### Benefits

Allows to see the current editor in the post list even if they are hierarchical.

![CleanShot 2021-06-11 at 13 21 33](https://user-images.githubusercontent.com/11416255/121717796-f7ca7a80-cab7-11eb-81b9-d77ef2d20ba0.png)

### Possible Drawbacks

None known.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
