### PR TITLE
Inner Block Transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Convert to Blocks is a WordPress plugin that transforms classic editor content t
 
 * PHP 7.0+
 * WordPress 5.4+
+* Inner Blocks Transforms is only supported with the Gutenberg Plugin 10.9.0+
 
 ## Installation
 
@@ -28,6 +29,10 @@ Find a classic editor in the post, try to navigate away from the page. You will 
 ### Will Convert to Blocks Handle My Custom Blocks?
 
 By default it will not.
+
+### Will Convert to Blocks Handle Nested Blocks?
+
+Nested / Inner Block support does not work with Gutenberg bundled with WordPress Core <=5.7.2. This feature needs the Gutenberg Plugin >=10.9.0.
 
 ## Support Level
 

--- a/assets/js/editor/transform/ClassicBlockTransformer.js
+++ b/assets/js/editor/transform/ClassicBlockTransformer.js
@@ -65,6 +65,8 @@ class ClassicBlockTransformer {
 			this.wp.data
 				.dispatch('core/block-editor')
 				.replaceBlocks(block.clientId, this.blockHandler(block));
+		} else if (block.innerBlocks && block.innerBlocks.length > 0) {
+			this.convertBlocks(block.innerBlocks);
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,8 @@ Convert to Blocks transforms classic editor content to blocks on-the-fly.
 
 Convert to Blocks is a WordPress plugin that transforms classic editor content to blocks on-the-fly.  After installing Gutenberg or upgrading to WordPress 5.0+, your content will be displayed in "Classic Editor Blocks".  While these blocks are completely functional and will display fine on the frontend of your website, they do not empower editors to fully make use of the block editing experience.  In order to do so, your classic editor posts need to be converted to blocks.  This plugin does that for you "on the fly".  When an editor goes to edit a classic post, the content will be parsed into blocks.  When the editor saves the post, the new structure will be saved into the database.  This strategy reduces risk as you are only altering database values for content that needs to be changed.
 
+**Note that Inner Blocks Transforms is only supported with the Gutenberg Plugin 10.9.0+.**
+
 == Installation ==
 
 = Manual Installation =
@@ -30,6 +32,10 @@ Find a classic editor in the post, try to navigate away from the page. You will 
 = Will Convert to Blocks Handle My Custom Blocks? =
 
 By default it will not.
+
+= Will Convert to Blocks Handle Nested Blocks? =
+
+Nested / Inner Block support does not work with Gutenberg bundled with WordPress Core <=5.7.2. This feature needs the Gutenberg Plugin >=10.9.0.
 
 == Screenshots ==
 


### PR DESCRIPTION
### Description of the Change

Fixes https://github.com/10up/convert-to-blocks/issues/42, when using the Gutenberg Plugin(10.9.0). Does not work with the Gutenberg version embedded in Core (v5.7.2).

In the embedded version, the Gutenberg replaceBlocks function does not update the block after we replace it's content.

### Verification Process

Given this post content,
https://gist.github.com/MadtownLems/42b65929ec2000bbe338e8f3b99f533a

The plugin now correctly converts the classic editor inner blocks inside the column blocks.

Result after compiling with $ npm run build on this feature branch.
https://imgur.com/a/A4ClEyU

### Checklist:

- [x ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [x ] All new and existing tests passed.

### Applicable Issues

https://github.com/10up/convert-to-blocks/issues/42

### Changelog Entry

* Transforms Classic Editor blocks nested inside other blocks recursively.
