### PR TITLE
Bulk Migration Support via WP CLI

### DIFF
--- a/assets/js/editor/transform/ClassicBlockTransformer.js
+++ b/assets/js/editor/transform/ClassicBlockTransformer.js
@@ -15,6 +15,8 @@ class ClassicBlockTransformer {
 
 	/**
 	 * Runs the Classic to Gutenberg Block transform on the current document.
+	 *
+	 * @returns {boolean} The result of the transformation.
 	 */
 	execute() {
 		const coreEditor = this.wp.data.select('core/block-editor');

--- a/assets/js/editor/transform/ClassicBlockTransformer.js
+++ b/assets/js/editor/transform/ClassicBlockTransformer.js
@@ -10,6 +10,7 @@ class ClassicBlockTransformer {
 	 */
 	constructor() {
 		this.wp = window.wp;
+		this.didTransform = false;
 	}
 
 	/**
@@ -23,6 +24,8 @@ class ClassicBlockTransformer {
 			/* Currently set to do 3 levels of recursion */
 			this.convertBlocks(blocks, 1, 3);
 		}
+
+		return this.didTransform;
 	}
 
 	/**
@@ -65,6 +68,8 @@ class ClassicBlockTransformer {
 			this.wp.data
 				.dispatch('core/block-editor')
 				.replaceBlocks(block.clientId, this.blockHandler(block));
+
+			this.didTransform = true;
 		} else if (block.innerBlocks && block.innerBlocks.length > 0) {
 			this.convertBlocks(block.innerBlocks);
 		}

--- a/assets/js/editor/transform/MigrationClient.js
+++ b/assets/js/editor/transform/MigrationClient.js
@@ -1,0 +1,104 @@
+const { wp, location } = window;
+
+/**
+ * MigrationClient provides the client-side support for the BE MigrationAgent.
+ */
+class MigrationClient {
+	/**
+	 * Initializes the client with the specified config settings.
+	 *
+	 * @param {object} config The convert to blocks config
+	 */
+	constructor(config) {
+		this.config = config;
+		this.saved = false;
+		this.didNext = false;
+	}
+
+	/**
+	 * Saves the curent post by manually dispatching savePost.
+	 */
+	save() {
+		// don't rerun after save
+		if (this.saved) {
+			return;
+		}
+
+		this.saved = true;
+
+		const { dispatch, subscribe } = wp.data;
+		const editor = dispatch('core/editor');
+
+		subscribe(this.didSave.bind(this));
+		editor.savePost();
+	}
+
+	/**
+	 * On Post save, runs the next post migration.
+	 */
+	didSave() {
+		const { select } = wp.data;
+		const isSavingPost = select('core/editor').isSavingPost();
+		const isAutosavingPost = select('core/editor').isAutosavingPost();
+
+		if (isAutosavingPost && !isSavingPost) {
+			return;
+		}
+
+		if (this.hasNext()) {
+			this.next();
+		}
+	}
+
+	/**
+	 * Checks if there is a post in the queue.
+	 *
+	 * @returns {boolean} True or false if next is present.
+	 */
+	hasNext() {
+		if (this.didNext) {
+			return false;
+		}
+
+		if (!this.hasNextConfig()) {
+			return false;
+		}
+
+		return this.config.agent.next;
+	}
+
+	/**
+	 * Navigates to the next post to migrate.
+	 */
+	next() {
+		if (!this.hasNextConfig()) {
+			return;
+		}
+
+		this.didNext = true;
+		location.href = this.config.agent.next;
+	}
+
+	/**
+	 * Checks if the next migration post data is present in config.
+	 *
+	 * @returns {boolean} True or false if next config is present
+	 */
+	hasNextConfig() {
+		if (!this.config) {
+			return false;
+		}
+
+		if (!this.config.agent) {
+			return false;
+		}
+
+		if (!this.config.agent.next) {
+			return false;
+		}
+
+		return true;
+	}
+}
+
+export default MigrationClient;

--- a/includes/ConvertToBlocks/MigrationAgent.php
+++ b/includes/ConvertToBlocks/MigrationAgent.php
@@ -66,7 +66,6 @@ class MigrationAgent {
 
 	/**
 	 * Stops the batch conversion if running and resets the previous session.
-	 *
 	 */
 	public function stop() {
 		update_option( 'ctb_running', 0 );

--- a/includes/ConvertToBlocks/MigrationAgent.php
+++ b/includes/ConvertToBlocks/MigrationAgent.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * MigrationAgent
+ *
+ * @package convert-to-blocks
+ */
+
+namespace ConvertToBlocks;
+
+/**
+ * MigrationAgent manages the batch conversion of posts from the WP CLI.
+ */
+class MigrationAgent {
+
+	/**
+	 * Registers the MigrationAgent with WordPress if required.
+	 */
+	public function register() {
+		if ( ! $this->has_ctb_client_param() ) {
+			return;
+		}
+
+		if ( ! $this->is_running() ) {
+			return;
+		}
+
+		wp_localize_script(
+			'convert_to_blocks_editor',
+			'convert_to_blocks_agent',
+			[
+				'agent' => [
+					'next' => $this->next(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Always register since this check needs to be happen later in lifecycle.
+	 *
+	 * @return bool
+	 */
+	public function can_register() {
+		return true;
+	}
+
+	/**
+	 * Starts the batch conversion
+	 *
+	 * @param array $opts Optional opts.
+	 * @return bool
+	 */
+	public function start( $opts = [] ) {
+		$posts_to_update = $this->get_posts_to_update( $opts );
+
+		if ( empty( $posts_to_update ) ) {
+			return false;
+		}
+
+		update_option( 'ctb_running', 1 );
+		update_option( 'ctb_posts_to_update', $posts_to_update );
+		update_option( 'ctb_cursor', -1 );
+
+		return $this->next();
+	}
+
+	/**
+	 * Stops the batch conversion if running and resets the previous session.
+	 *
+	 * @return bool
+	 */
+	public function stop() {
+		update_option( 'ctb_running', 0 );
+		update_option( 'ctb_posts_to_update', [] );
+		update_option( 'ctb_cursor', -1 );
+	}
+
+	/**
+	 * Returns the current status of the batch conversion.
+	 *
+	 * @return array
+	 */
+	public function get_status() {
+		$running         = get_option( 'ctb_running' );
+		$posts_to_update = get_option( 'ctb_posts_to_update' );
+
+		if ( empty( $posts_to_update ) ) {
+			$posts_to_update = [];
+		}
+
+		$total  = count( $posts_to_update );
+		$cursor = get_option( 'ctb_cursor' );
+
+		if ( $total > 0 ) {
+			$progress = round( ( $cursor + 1 ) / $total * 100 );
+		} else {
+			$progress = 0;
+		}
+
+		return [
+			'running'  => $running,
+			'cursor'   => $cursor,
+			'total'    => $total,
+			'progress' => $progress,
+			'active'   => $this->get_client_link( $posts_to_update[ $cursor ] ?? 0 ),
+		];
+	}
+
+	/**
+	 * Returns a boolean based on whether a migration is currently running.
+	 *
+	 * @return bool
+	 */
+	public function is_running() {
+		$running = get_option( 'ctb_running' );
+		return ! empty( $running );
+	}
+
+	/**
+	 * Updates the progress cursor to jump to the next post in the queue.
+	 */
+	public function next() {
+		$posts_to_update = get_option( 'ctb_posts_to_update' );
+		$total           = count( $posts_to_update );
+		$cursor          = get_option( 'ctb_cursor' );
+
+		if ( $cursor + 1 < $total ) {
+			$next_cursor = ++$cursor;
+			update_option( 'ctb_cursor', $next_cursor );
+
+			return $this->get_client_link( $posts_to_update[ $next_cursor ] );
+		} elseif ( $cursor + 1 === $total ) {
+			update_option( 'ctb_running', 0 );
+			return false;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Returns the next post URL to migrate.
+	 *
+	 * @param int $post_id The next post id.
+	 * @return string
+	 */
+	public function get_client_link( $post_id ) {
+		if ( empty( $post_id ) ) {
+			return '';
+		}
+
+		$edit_post_link = admin_url( 'post.php' );
+
+		$args = [
+			'post'       => $post_id,
+			'action'     => 'edit',
+			'ctb_client' => $post_id,
+		];
+
+		return add_query_arg( $args, $edit_post_link );
+	}
+
+	/**
+	 * Returns the list of post ids that need to be migrated.
+	 *
+	 * @param array $opts Optional opts
+	 * @return array
+	 */
+	public function get_posts_to_update( $opts = [] ) {
+		if ( ! empty( $opts['post_type'] ) ) {
+			$post_type = explode( ',', $opts['post_type'] );
+			$post_type = array_filter( $post_type );
+
+			if ( empty( $post_type ) ) {
+				$post_type = [ 'post', 'page' ];
+			}
+		} else {
+			$post_type = [ 'post', 'page' ];
+		}
+
+		$query_params = [
+			'post_type'           => $post_type,
+			'post_status'         => 'publish',
+			'fields'              => 'ids',
+			'posts_per_page'      => -1,
+			'ignore_sticky_posts' => true,
+		];
+
+		if ( ! empty( $opts['only'] ) ) {
+			$post_in = explode( ',', $opts['only'] );
+			$post_in = array_map( 'intval', $post_in );
+			$post_in = array_filter( $post_in );
+
+			$query_params['post__in'] = $post_in;
+		}
+
+		$query = new \WP_Query( $query_params );
+		$posts = $query->posts;
+
+		return $posts;
+	}
+
+	/**
+	 * Returns a boolean based on whether the current url has the ctb_client
+	 * editor parameter
+	 *
+	 * @return bool
+	 */
+	public function has_ctb_client_param() {
+		// phpcs:disable
+		$ctb_client = sanitize_text_field( isset( $_GET['ctb_client'] ) ? $_GET['ctb_client'] : '' ) ;
+		// phpcs:enable
+		$ctb_client = intval( $ctb_client );
+
+		return ! empty( $ctb_client );
+	}
+
+}

--- a/includes/ConvertToBlocks/MigrationAgent.php
+++ b/includes/ConvertToBlocks/MigrationAgent.php
@@ -205,7 +205,7 @@ class MigrationAgent {
 	 */
 	public function has_ctb_client_param() {
 		// phpcs:disable
-		$ctb_client = sanitize_text_field( isset( $_GET['ctb_client'] ) ? $_GET['ctb_client'] : '' ) ;
+		$ctb_client = sanitize_text_field( $_GET['ctb_client'] ?? '' );
 		// phpcs:enable
 		$ctb_client = intval( $ctb_client );
 

--- a/includes/ConvertToBlocks/MigrationAgent.php
+++ b/includes/ConvertToBlocks/MigrationAgent.php
@@ -67,7 +67,6 @@ class MigrationAgent {
 	/**
 	 * Stops the batch conversion if running and resets the previous session.
 	 *
-	 * @return bool
 	 */
 	public function stop() {
 		update_option( 'ctb_running', 0 );

--- a/includes/ConvertToBlocks/MigrationCommand.php
+++ b/includes/ConvertToBlocks/MigrationCommand.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * MigrationCommand
+ *
+ * @package convert-to-blocks
+ */
+
+namespace ConvertToBlocks;
+
+/**
+ * Bulk migrates classic editor posts to Gutenberg blocks.
+ */
+class MigrationCommand extends \WP_CLI_Command {
+
+	/**
+	 * Starts a new Migration. The command prints the URL that must be opened in a browser to connect it to the WP CLI.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<post_type>]
+	 * : Optional comma delimited list of post types to migrate. Defaults to post,page
+	 *
+	 * [<only>]
+	 * : Optional comma delimited list of post ids to migrate.
+	 *
+	 * @synopsis [--post_type=<post_type>]
+	 * @synopsis [--only=<only>]
+	 */
+	public function start( $args = [], $opts = [] ) {
+		$agent = new MigrationAgent();
+		$delay = 5; // 5 second delay between each tick
+
+		if ( $agent->is_running() ) {
+			\WP_CLI::error( 'Please stop the currently running migration first.' );
+		}
+
+		$result = $agent->start( $opts );
+
+		if ( empty( $result ) ) {
+			\WP_CLI::error( 'No posts to migrate.' );
+		}
+
+		$status = $agent->get_status( $opts );
+
+		if ( ! $status['running'] ) {
+			\WP_CLI::error( 'Failed to start migration.' );
+		}
+
+		\WP_CLI::log( 'Migration started.' );
+		\WP_CLI::log( 'Please open the following URL in a browser to start the migration agent.' );
+		\WP_CLI::line( '' );
+		\WP_CLI::log( $result );
+		\WP_CLI::line( '' );
+
+		$total = $status['total'];
+
+		$message      = "Converting $total Posts ...";
+		$progress_bar = \WP_CLI\Utils\make_progress_bar( $message, $total );
+		$progress_bar->tick();
+
+		$prev_progress = -1;
+
+		while ( true ) {
+			$status = $agent->get_status();
+
+			if ( ! $status['running'] ) {
+				break;
+			}
+
+			$progress = $status['progress'];
+
+			if ( $progress !== $prev_progress ) {
+				$progress_bar->tick( $progress - $prev_progress );
+				$prev_progress = $progress;
+			}
+
+			sleep( $delay );
+
+			// required as we need to reload options that the browser client is updating
+			wp_cache_delete( 'alloptions', 'options' );
+		}
+
+		$progress_bar->finish();
+
+		\WP_CLI::success( 'Migration finished successfully.' );
+
+		// cleanup the options used during migration
+		$agent->stop();
+	}
+
+	/**
+	 * Stops the currently running migration if active.
+	 */
+	public function stop( $args = [], $opts = [] ) {
+		$agent = new MigrationAgent();
+
+		if ( ! $agent->is_running() ) {
+			\WP_CLI::warning( 'No migrations are currently running' );
+			return;
+		}
+
+		$agent->stop( $opts );
+
+		\WP_CLI::success( 'Migration stopped successfully' );
+	}
+
+	/**
+	 * Prints the status of the currently running migration.
+	 */
+	public function status( $args = [], $opts = [] ) {
+		$agent  = new MigrationAgent();
+		$status = $agent->get_status( $opts );
+
+		if ( ! $status['running'] ) {
+			\WP_CLI::log( 'No migrations are currently running.' );
+			return;
+		}
+
+		\WP_CLI::log( 'Migration is currently running ...' );
+		\WP_CLI::log( $status['progress'] . ' [' . ( $status['cursor'] + 1 ) . '/' . $status['total'] . ']' );
+		\WP_CLI::log( 'Active: ' . $status['active'] );
+	}
+
+}

--- a/includes/ConvertToBlocks/MigrationCommand.php
+++ b/includes/ConvertToBlocks/MigrationCommand.php
@@ -62,7 +62,7 @@ class MigrationCommand extends \WP_CLI_Command {
 		$progress_bar->tick();
 
 		$prev_progress = 0;
-		$ticks = 0;
+		$ticks         = 0;
 
 		while ( true ) {
 			$status = $agent->get_status();

--- a/includes/ConvertToBlocks/MigrationCommand.php
+++ b/includes/ConvertToBlocks/MigrationCommand.php
@@ -25,6 +25,9 @@ class MigrationCommand extends \WP_CLI_Command {
 	 *
 	 * @synopsis [--post_type=<post_type>]
 	 * @synopsis [--only=<only>]
+	 *
+	 * @param array $args The command args
+	 * @param array $opts The command opts
 	 */
 	public function start( $args = [], $opts = [] ) {
 		$agent = new MigrationAgent();
@@ -90,6 +93,9 @@ class MigrationCommand extends \WP_CLI_Command {
 
 	/**
 	 * Stops the currently running migration if active.
+	 *
+	 * @param array $args The command args
+	 * @param array $opts The command opts
 	 */
 	public function stop( $args = [], $opts = [] ) {
 		$agent = new MigrationAgent();
@@ -106,6 +112,9 @@ class MigrationCommand extends \WP_CLI_Command {
 
 	/**
 	 * Prints the status of the currently running migration.
+	 *
+	 * @param array $args The command args
+	 * @param array $opts The command opts
 	 */
 	public function status( $args = [], $opts = [] ) {
 		$agent  = new MigrationAgent();

--- a/includes/ConvertToBlocks/MigrationCommand.php
+++ b/includes/ConvertToBlocks/MigrationCommand.php
@@ -49,7 +49,7 @@ class MigrationCommand extends \WP_CLI_Command {
 			\WP_CLI::error( 'Failed to start migration.' );
 		}
 
-		\WP_CLI::log( 'Migration started.' );
+		\WP_CLI::log( 'Migration started...' );
 		\WP_CLI::log( 'Please open the following URL in a browser to start the migration agent.' );
 		\WP_CLI::line( '' );
 		\WP_CLI::log( $result );

--- a/includes/ConvertToBlocks/Plugin.php
+++ b/includes/ConvertToBlocks/Plugin.php
@@ -116,6 +116,7 @@ class Plugin {
 				new RevisionSupport(),
 				new ClassicEditorSupport(),
 				new Assets(),
+				new MigrationAgent(),
 			]
 		);
 	}
@@ -124,6 +125,7 @@ class Plugin {
 	 * Initializes the Plugin WP CLI commands
 	 */
 	public function init_commands() {
+		\WP_CLI::add_command( 'convert-to-blocks', '\ConvertToBlocks\MigrationCommand' );
 	}
 
 	/* Helpers */


### PR DESCRIPTION
### Description of the Change

This PR adds support for bulk migration of classic editor posts to Gutenberg Blocks. The implementation provides a WP CLI command to start and monitor the progress of the migration. When started the CLI outputs a link that must be opened in a browser window. The browser window will convert classic editor content to blocks and then move on to the next post, and so forth until all posts are converted. Posts that are already converted to blocks are skipped.

The following screencast shows this in action.

![bulk_migration_demo](https://user-images.githubusercontent.com/3541543/175513620-794c16a2-f83c-40c2-90fa-0d47abd92cce.gif)

Closes #56

### Verification Process

To verify this you need a WordPress database with classic editor content. Then run the WP CLI as follows. The CLI will output a URL that needs to be opened in the Browser. (You should be logged in to the WordPress before hand.)

```
$ wp convert-to-blocks start
```

I've tested this on a recent production migration with <1000 posts. Larger migrations are also possible but will take longer to complete.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

Added - WP CLI based bulk migration support

### Credits

Props @dsawardekar
