### PR TITLE
Updates Migration Command helptext to fix #77

### DIFF
--- a/includes/ConvertToBlocks/MigrationCommand.php
+++ b/includes/ConvertToBlocks/MigrationCommand.php
@@ -17,14 +17,11 @@ class MigrationCommand extends \WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * [<post_type>]
+	 * [--post_type=<post_type>]
 	 * : Optional comma delimited list of post types to migrate. Defaults to post,page
 	 *
-	 * [<only>]
+	 * [--only=<only>]
 	 * : Optional comma delimited list of post ids to migrate.
-	 *
-	 * @synopsis [--post_type=<post_type>]
-	 * @synopsis [--only=<only>]
 	 *
 	 * @param array $args The command args
 	 * @param array $opts The command opts


### PR DESCRIPTION
### Description of the Change

Fixes the WP CLI helptext that is causing the unknown parameter error seen in #77.

Closes #77 

### How to test the Change

Run the CLI command with the `--only` or `--post_type` flags.

```
$ wp convert-to-blocks start --only=31,65
```

### Changelog Entry

Fixed - Fixes the WP CLI helptext that is causing the unknown parameter error seen in #77.

### Credits

@dsawardekar 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
