### PR TITLE
Post type setting field added

### DIFF
--- a/includes/ConvertToBlocks/Plugin.php
+++ b/includes/ConvertToBlocks/Plugin.php
@@ -32,8 +32,8 @@ class Plugin {
 	 *
 	 * @var array
 	 */
-	private static $default_post_types = array( 
-		'post', 
+	private static $default_post_types = array(
+		'post',
 		'page',
 	);
 
@@ -145,7 +145,7 @@ class Plugin {
 	 *
 	 * @return void
 	 */
-	function convert_to_block_setting_form() {
+	public function convert_to_block_setting_form() {
 		$post_types = get_post_types( array( 'show_in_rest' => true ) );
 		$options    = get_option( self::POST_TYPE_FIELD, self::$default_post_types );
 
@@ -153,7 +153,7 @@ class Plugin {
 			$post_type = get_post_type_object( $type );
 			$id        = 'cb-supported-post-types-' . $type;
 			?>
-			<input id="<?php echo esc_attr( $id ); ?>" type="checkbox" name="<?php echo self::POST_TYPE_FIELD; ?>[]" value="<?php echo esc_attr( $type ); ?>" <?php echo in_array( $type, $options ) ? 'checked="checked"' : ''; ?>/>
+			<input id="<?php echo esc_attr( $id ); ?>" type="checkbox" name="<?php echo esc_attr( self::POST_TYPE_FIELD ); ?>[]" value="<?php echo esc_attr( $type ); ?>" <?php echo in_array( $type, $options, true ) ? 'checked="checked"' : ''; ?>/>
 			<label for="<?php echo esc_attr( $id ); ?>"><?php echo esc_html( $post_type->label ); ?></label><br/>
 			<?php
 		}

--- a/includes/ConvertToBlocks/Plugin.php
+++ b/includes/ConvertToBlocks/Plugin.php
@@ -149,6 +149,10 @@ class Plugin {
 		$post_types = get_post_types( array( 'show_in_rest' => true ) );
 		$options    = get_option( self::POST_TYPE_FIELD, CONVERT_TO_BLOCKS_DEFAULT_POST_TYPES );
 
+		if ( ! is_array( $options ) ) {
+			$options = array();
+		}
+
 		foreach ( $post_types as $type ) {
 			if ( ! use_block_editor_for_post_type( $type ) ) {
 				continue;
@@ -316,6 +320,11 @@ class Plugin {
 	 */
 	public function get_default_post_types() {
 		$defaults = get_option( self::POST_TYPE_FIELD, CONVERT_TO_BLOCKS_DEFAULT_POST_TYPES );
+		
+		if ( ! is_array( $defaults ) ) {
+			$defaults = array();
+		}
+
 		return apply_filters( 'convert_to_blocks_default_post_types', $defaults );
 	}
 

--- a/includes/ConvertToBlocks/Plugin.php
+++ b/includes/ConvertToBlocks/Plugin.php
@@ -320,7 +320,7 @@ class Plugin {
 	 */
 	public function get_default_post_types() {
 		$defaults = get_option( self::POST_TYPE_FIELD, CONVERT_TO_BLOCKS_DEFAULT_POST_TYPES );
-		
+
 		if ( ! is_array( $defaults ) ) {
 			$defaults = array();
 		}

--- a/includes/ConvertToBlocks/Plugin.php
+++ b/includes/ConvertToBlocks/Plugin.php
@@ -141,6 +141,15 @@ class Plugin {
 	}
 
 	/**
+	 * Setting section header
+	 * 
+	 * @return void
+	 */
+	public function settings_intro() {
+		echo '<p>' . __( 'Settings for Convert to Blocks', 'convert-to-blocks' ) . '</p>';
+	}
+
+	/**
 	 * Render convert to block setting form
 	 *
 	 * @return void

--- a/includes/ConvertToBlocks/Plugin.php
+++ b/includes/ConvertToBlocks/Plugin.php
@@ -142,11 +142,11 @@ class Plugin {
 
 	/**
 	 * Setting section header
-	 * 
+	 *
 	 * @return void
 	 */
 	public function settings_intro() {
-		echo '<p>' . __( 'Settings for Convert to Blocks', 'convert-to-blocks' ) . '</p>';
+		echo '<p>' . esc_html__( 'Settings for Convert to Blocks', 'convert-to-blocks' ) . '</p>';
 	}
 
 	/**
@@ -159,6 +159,10 @@ class Plugin {
 		$options    = get_option( self::POST_TYPE_FIELD, self::$default_post_types );
 
 		foreach ( $post_types as $type ) {
+			if ( ! use_block_editor_for_post_type( $type ) ) {
+				continue;
+			}
+
 			$post_type = get_post_type_object( $type );
 			$id        = 'cb-supported-post-types-' . $type;
 			?>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
As per current implementation, there is no way to resolve the issue other than explicitly adding `convert-to-blocks` support during custom post type registration. So, a new field added in writing setting page to enable/disable `Convert to Blocks` for specific post types without editing code.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #57 

### How to test the Change

- Register custom post type
- Edit/create post
- Toggle the post type in writing setting page under `Convert to Blocks` section
- Check if Gutenberg editor gets enabled/disabled for that post type correctly

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Setting field added to enable/disable specific custom post type


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jayedul 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
