### PR TITLE
Introduce a new hook to allow filtering the query parameters for the query that fetches the posts to be updated

### DIFF
--- a/includes/ConvertToBlocks/MigrationAgent.php
+++ b/includes/ConvertToBlocks/MigrationAgent.php
@@ -183,6 +183,21 @@ class MigrationAgent {
 			'ignore_sticky_posts' => true,
 		];
 
+		/**
+		 * Filter query parameters for the query to get the posts to be updated.
+		 *
+		 * @since 1.1.2
+		 *
+		 * @hook convert_to_blocks_update_posts_query_params
+		 *
+		 * @param {array} $query_params Array of query parameters.
+		 * @param {array} $post_type    Array with the post types.
+		 * @param {array} $opts         Optional opts.
+		 *
+		 * @return {array} Array of request arguments.
+		 */
+		$query_params = apply_filters( 'convert_to_blocks_update_posts_query_params', $query_params, $post_type, $opts );
+
 		if ( ! empty( $opts['only'] ) ) {
 			$post_in = explode( ',', $opts['only'] );
 			$post_in = array_map( 'intval', $post_in );


### PR DESCRIPTION
### Description of the Change
In this MR I'm adding a new filter to allow filtering the query parameters of the query that fetches the posts to be updated.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/convert-to-blocks/issues/105

### How to test the Change
Add a filter callback to a theme's or plugin's code and verify that a custom query parameter can be added in the parameters' array for the query.

### Changelog Entry
> Added - Adding a new filter to allow filtering the query parameters of the query that fetches the posts to be updated.


### Credits
Props @sanketio for requesting this.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
