### PR TITLE
Update our deploy action to run under node 16

### DIFF
--- a/.github/workflows/dotorg-push-deploy.yml
+++ b/.github/workflows/dotorg-push-deploy.yml
@@ -1,18 +1,27 @@
 name: Deploy to WordPress.org
+
 on:
   release:
     types: [published]
+
 jobs:
   tag:
     name: New release
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+
+    - name: Setup node version
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
     - name: Build
       run: |
         npm install
         npm run build
+
     - name: WordPress Plugin Deploy
       id: deploy
       uses: 10up/action-wordpress-plugin-deploy@stable
@@ -21,6 +30,7 @@ jobs:
       env:
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+
     - name: Upload release asset
       uses: actions/upload-release-asset@v1
       env:


### PR DESCRIPTION
### Description of the Change

Our Deploy to WordPress.org action is [failing](https://github.com/10up/convert-to-blocks/actions/runs/5394912535/jobs/9796740265) and it appears to be an issue with the node version that the action runs under and the webpack version the plugin uses to build assets.

Found this [answer](https://stackoverflow.com/a/70582385) that talks about changes in node v17+ that conflict with webpack v4. While it would be ideal to update this plugin to use the latest version of webpack, the easy approach for now is to run our deploy action under node 16.

### How to test the Change

Can't test for sure until we trigger the deploy action but you can test locally by installing node 16 and running `npm run build`. That command should work.