### PR TITLE
Add a PHP version check and disable functionality if a site doesn't meet requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased] - TBD
 
-## [1.2.1] - 2023-07-25
+## [1.2.1] - 2023-07-26
+### Added
+- More robust minimum PHP version check (props [@dkotter](https://github.com/dkotter), [@ravinderk](https://github.com/ravinderk) via [#129](https://github.com/10up/convert-to-blocks/pull/129)).
+
 ### Changed
 - Bump minimum required PHP version from 7.4 to 8.0 in our `composer.json` config (props [@c0ntax](https://github.com/c0ntax), [@Sidsector9](https://github.com/Sidsector9) via [#122](https://github.com/10up/convert-to-blocks/pull/122)).
 
@@ -119,6 +122,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 - Initial release of Convert to Blocks.
 
 [Unreleased]: https://github.com/10up/convert-to-blocks/compare/trunk...develop
+[1.2.1]: https://github.com/10up/convert-to-blocks/compare/1.2.0...1.2.1
 [1.2.0]: https://github.com/10up/convert-to-blocks/compare/1.1.1...1.2.0
 [1.1.1]: https://github.com/10up/convert-to-blocks/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/10up/convert-to-blocks/compare/1.0.2...1.1.0

--- a/convert-to-blocks.php
+++ b/convert-to-blocks.php
@@ -5,7 +5,7 @@
  * Description:       Convert classic editor posts to blocks on the fly.
  * Version:           1.2.1
  * Requires at least: 6.1
- * Requires PHP:      8
+ * Requires PHP:      8.0
  * Author:            10up
  * Author URI:        https://10up.com
  * License:           GPLv2 or later

--- a/convert-to-blocks.php
+++ b/convert-to-blocks.php
@@ -45,6 +45,52 @@ function convert_to_blocks_get_setting( $name ) {
 	return apply_filters( 'convert_to_blocks_setting_' . $name, constant( $name ), \get_current_blog_id() );
 }
 
+/**
+ * Get the minimum version of PHP required by this plugin.
+ *
+ * @since 1.2.1
+ *
+ * @return string Minimum version required.
+ */
+function convert_to_blocks_minimum_php_requirement() {
+	return '8.0';
+}
+
+/**
+ * Whether PHP installation meets the minimum requirements
+ *
+ * @since 1.2.1
+ *
+ * @return bool True if meets minimum requirements, false otherwise.
+ */
+function convert_to_blocks_site_meets_php_requirements() {
+	return version_compare( phpversion(), convert_to_blocks_minimum_php_requirement(), '>=' );
+}
+
+if ( ! convert_to_blocks_site_meets_php_requirements() ) {
+	add_action(
+		'admin_notices',
+		function() {
+			?>
+			<div class="notice notice-error">
+				<p>
+					<?php
+					echo wp_kses_post(
+						sprintf(
+							/* translators: %s: Minimum required PHP version */
+							__( 'Convert to Blocks requires PHP version %s or later. Please upgrade PHP or disable the plugin.', 'convert-to-blocks' ),
+							esc_html( convert_to_blocks_minimum_php_requirement() )
+						)
+					);
+					?>
+				</p>
+			</div>
+			<?php
+		}
+	);
+	return;
+}
+
 if ( file_exists( __DIR__ . '/config.test.php' ) && defined( 'PHPUNIT_RUNNER' ) ) {
 	require_once __DIR__ . '/config.test.php';
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      10up, dsawardekar, tlovett1, jeffpaul
 Tags:              gutenberg, block, block migration, gutenberg migration, gutenberg conversion, convert to blocks
 Requires at least: 5.7
 Tested up to:      6.2
-Requires PHP:      7.4
+Requires PHP:      8.0
 Stable tag:        1.2.1
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
@@ -43,7 +43,8 @@ Nested / Inner Block support does not work with Gutenberg bundled with WordPress
 
 == Changelog ==
 
-= 1.2.1 - 2023-07-25 =
+= 1.2.1 - 2023-07-26 =
+* **Added:** More robust minimum PHP version check (props [@dkotter](https://github.com/dkotter), [@ravinderk](https://github.com/ravinderk) via [#129](https://github.com/10up/convert-to-blocks/pull/129)).
 * **Changed:** Bump minimum required PHP version from 7.4 to 8.0 in our `composer.json` config (props [@c0ntax](https://github.com/c0ntax), [@Sidsector9](https://github.com/Sidsector9) via [#122](https://github.com/10up/convert-to-blocks/pull/122)).
 * **Fixed:** Parse error caused by a comma (props [@Sidsector9](https://github.com/Sidsector9), [@iamdharmesh](https://github.com/iamdharmesh), [@ravinderk](https://github.com/ravinderk), [@felipeelia](https://github.com/felipeelia) via [#123](https://github.com/10up/convert-to-blocks/pull/123)).
 * **Security:** Bump `minimist` from 1.2.0 to 1.2.7 and `mkdirp` from 0.5.1 to 0.5.6 (props [@dependabot](https://github.com/apps/dependabot) via [#117](https://github.com/10up/convert-to-blocks/pull/117)).


### PR DESCRIPTION
### Description of the Change

In the last release we bumped the minimum PHP version to 8.0. What we've found in the past is that sometimes sites are able to bypass the restrictions WordPress has in place around minimum versions and end up getting fatal errors when their site doesn't meet the requirements (for example, they may be running PHP 7.4 and somehow are able to install the latest version of the plugin which requires PHP 8.0, resulting in a fatal error).

This PR helps resolve that by adding a check before we load any of our plugin functionality. If a site doesn't meet our minimum requirements (in this case, PHP < 8.0) we output an admin notice and we don't load any more functionality.

Closes #125 

### How to test the Change

1. Checkout the `develop` branch and run `npm run build-release`
2. Create an environment running PHP 8.0+
3. Install and activate the plugin and note that things work
4. Downgrade the PHP version on that environment to 7.4
5. Note a fatal error is encountered
6. Checkout this branch and run `npm run build-release` again
7. Ensure the plugin shows an admin notice when running PHP 7.4 and works as expected with PHP 8.0+

### Changelog Entry

> Added - More robust minimum PHP version check.

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
