### PR TITLE
Add support for the WordPress.org plugin preview

### DIFF
--- a/.github/workflows/dotorg-asset-readme-update.yml
+++ b/.github/workflows/dotorg-asset-readme-update.yml
@@ -1,16 +1,31 @@
 name: Plugin asset/readme update
+
 on:
   push:
     branches:
     - trunk
+
 jobs:
   trunk:
     name: Push to trunk
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: WordPress.org plugin asset/readme update
-      uses: 10up/action-wordpress-plugin-asset-update@stable
-      env:
-        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup node version
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Build
+        run: |
+          npm install
+          npm run build
+
+      - name: WordPress.org plugin asset/readme update
+        uses: 10up/action-wordpress-plugin-asset-update@stable
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -1,0 +1,33 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "\/wp-admin\/edit.php?post_type=post",
+	"preferredVersions": {
+		"php": "8.0",
+		"wp": "latest"
+	},
+	"phpExtensionBundles": ["kitchen-sink"],
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		},
+		{
+			"step": "importFile",
+			"file": {
+				"resource": "url",
+        "url": "https:\/\/raw.githubusercontent.com\/WordPress\/theme-test-data\/42c0fdc29d0055c276fc9fdd335a672a8133c605\/theme-preview.xml"
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginZipFile": {
+				"resource": "wordpress.org\/plugins",
+				"slug": "convert-to-blocks"
+			},
+			"options": {
+				"activate": true
+			}
+		}
+	]
+}


### PR DESCRIPTION
### Description of the Change

WordPress.org recently launched support for plugin previews utilizing the WordPress Playground feature. Plugins wanting to take advantage of this need to opt in by setting up a `blueprint.json` file that configures how the preview should load. This PR adds in that file that does the following:

1. Sets up an environment running PHP 8.0 (our supported minimum) and the latest version of WordPress
2. Logs into the admin
3. Imports some test content
4. Installs and activates the plugin
6. Sends the user to the posts list screen where they can click into a Classic Editor post to see the conversion

Note that this PR is targeted to `trunk` as the hope is we can take advantage of our Plugin Asset Update Action to deploy these changes without having to push out a new release. This PR also updates our Asset Deploy workflow to hopefully avoid issues related to differing files on Github as compared to .org.

Also note once these changes are on .org, the preview button will need to be enabled in a test state. Once verified as working, we can enable it for all users.

### How to test the Change

The WordPress Playground allows you to spin up a new environment directly through the URL, by going to `https://playground.wordpress.net/#` and pasting your JSON config after the `#`. In this case, the URL should be: https://playground.wordpress.net/#{%22$schema%22:%22https://playground.wordpress.net/blueprint-schema.json%22,%22landingPage%22:%22/wp-admin/edit.php?post_type=post%22,%22preferredVersions%22:{%22php%22:%228.0%22,%22wp%22:%22latest%22},%22phpExtensionBundles%22:[%22kitchen-sink%22],%22steps%22:[{%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22},{%22step%22:%22importFile%22,%22file%22:{%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/theme-test-data/42c0fdc29d0055c276fc9fdd335a672a8133c605/theme-preview.xml%22}},{%22step%22:%22installPlugin%22,%22pluginZipFile%22:{%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22convert-to-blocks%22},%22options%22:{%22activate%22:true}}]}

### Changelog Entry

> Added - Support for the WordPress.org plugin preview

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
