### PR TITLE
fix/170v2: add filter to delay post saving.

### DIFF
--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -66,9 +66,15 @@ class ConvertToBlocksEditorSupport {
 						return null;
 					}
 
-					setTimeout(() => {
+					const saveDelay = config?.agent?.save_delay || 0;
+
+					if (saveDelay > 0) {
+						setTimeout(() => {
+							client.save();
+						}, saveDelay);
+					} else {
 						client.save();
-					}, config.agent.save_delay);
+					}
 
 					return null;
 				}, 500);

--- a/assets/js/editor/editor.js
+++ b/assets/js/editor/editor.js
@@ -66,7 +66,9 @@ class ConvertToBlocksEditorSupport {
 						return null;
 					}
 
-					client.save();
+					setTimeout(() => {
+						client.save();
+					}, config.agent.save_delay);
 
 					return null;
 				}, 500);

--- a/includes/ConvertToBlocks/MigrationAgent.php
+++ b/includes/ConvertToBlocks/MigrationAgent.php
@@ -35,7 +35,7 @@ class MigrationAgent {
 			[
 				'agent' => [
 					'next'       => $this->next(),
-					'save_delay' => apply_filters( 'convert_to_blocks_save_delay', 500, $post_id )
+					'save_delay' => apply_filters( 'convert_to_blocks_save_delay', 0, $post_id )
 				],
 			]
 		);

--- a/includes/ConvertToBlocks/MigrationAgent.php
+++ b/includes/ConvertToBlocks/MigrationAgent.php
@@ -24,12 +24,18 @@ class MigrationAgent {
 			return;
 		}
 
+		$posts_to_update = get_option( 'ctb_posts_to_update' );
+		$cursor          = get_option( 'ctb_cursor' );
+		$posts_to_update = is_array( $posts_to_update ) ? $posts_to_update : [];
+		$post_id         = $posts_to_update[ $cursor ] ?? 0;
+
 		wp_localize_script(
 			'convert_to_blocks_editor',
 			'convert_to_blocks_agent',
 			[
 				'agent' => [
-					'next' => $this->next(),
+					'next'       => $this->next(),
+					'save_delay' => apply_filters( 'convert_to_blocks_save_delay', 500, $post_id )
 				],
 			]
 		);


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #170 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Activate classic editor.
2. Create 2 posts with gallery and add `heading`. (Just to test if the PR works as expected to transform other elements to blocks).
3. Disable the classic editor.
4. Run the following: `wp convert-to-blocks start --post_type=post`
5. Open the URL displayed in the terminal.
6. It will start converting blocks in both the posts.
7. Wait until terminal shows the message: "Migration finished successfully."
8. Open both the posts and reload the page to verify if the transformed blocks are visible as expected.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - issue with saving post before the convert to blocks transform completed.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @mdesplenter, @Sidsector9 @dsawardekar 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
