### PR TITLE
Bump WordPress "tested up to" version 6.6

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest', continue: false}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.3', continue: false}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.4', continue: false}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master', continue: true}
     steps:
     - name: Checkout

--- a/convert-to-blocks.php
+++ b/convert-to-blocks.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/convert-to-blocks
  * Description:       Convert classic editor posts to blocks on the fly.
  * Version:           1.3.0
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP:      8.0
  * Author:            10up
  * Author URI:        https://10up.com

--- a/includes/ConvertToBlocks/MigrationAgent.php
+++ b/includes/ConvertToBlocks/MigrationAgent.php
@@ -35,7 +35,7 @@ class MigrationAgent {
 			[
 				'agent' => [
 					'next'       => $this->next(),
-					'save_delay' => apply_filters( 'convert_to_blocks_save_delay', 0, $post_id )
+					'save_delay' => apply_filters( 'convert_to_blocks_save_delay', 0, $post_id ),
 				],
 			]
 		);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@10up/cypress-wp-utils": "^0.2.0",
         "@10up/eslint-config": "^4.0.0",
-        "@wordpress/env": "^8.9.0",
+        "@wordpress/env": "^10.2.0",
         "@wordpress/scripts": "^27.8.0",
         "cypress": "^13.3.0",
         "cypress-mochawesome-reporter": "^3.6.0",
@@ -4575,14 +4575,14 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-8.13.0.tgz",
-      "integrity": "sha512-rtrrBO22DnbLsdBlsGqlMQrjz1dZfbwGnxyKev+gFd1rSfmLs+1F8L89RHOx9vsGPixl5uRwoU/qgYo7Hf1NVQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.2.0.tgz",
+      "integrity": "sha512-EToZYPGXpl42Asw3bxpX8aKmHfRUdGxKPjQ9CHZVQoTAL27Af4FyjyGnepsnDpnYdIeI8VPb2S3k2NL/1+fpIA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "copy-dir": "^1.3.0",
-        "docker-compose": "^0.22.2",
+        "docker-compose": "^0.24.3",
         "extract-zip": "^1.6.7",
         "got": "^11.8.5",
         "inquirer": "^7.1.0",
@@ -4595,6 +4595,10 @@
       },
       "bin": {
         "wp-env": "bin/wp-env"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/hooks": {
@@ -8294,12 +8298,27 @@
       }
     },
     "node_modules/docker-compose": {
-      "version": "0.22.2",
-      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.22.2.tgz",
-      "integrity": "sha512-iXWb5+LiYmylIMFXvGTYsjI1F+Xyx78Jm/uj1dxwwZLbWkUdH6yOXY5Nr3RjbYX15EgbGJCq78d29CmWQQQMPg==",
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
       "dev": true,
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/docker-compose/node_modules/yaml": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/doctrine": {
@@ -19316,18 +19335,35 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.24.0.tgz",
-      "integrity": "sha512-QqAKee9Twv+3k8IFOFfPB2hnk6as6Y6ACUpwCtQvRYBAes23Wv3SZlHVobAzqcE8gfsisCvPw3HGW3HYM+VYYw==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.25.0.tgz",
+      "integrity": "sha512-KIY5sBnzc4yEcJXW7Tdv4viEz8KyG+nU0hay+DWZasvdFOYKeUZ6Xc25LUHHjw0tinPT7O1eY6pzX7pRT1K8rw==",
       "dev": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.3.4"
+        "debug": "^4.3.5"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
+    "node_modules/simple-git/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/sirv": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "devDependencies": {
         "@10up/cypress-wp-utils": "^0.2.0",
         "@10up/eslint-config": "^4.0.0",
-        "@wordpress/dependency-extraction-webpack-plugin": "^6.1.0",
         "@wordpress/env": "^10.2.0",
         "@wordpress/scripts": "^27.8.0",
         "cypress": "^13.3.0",
@@ -4535,22 +4534,6 @@
       "dev": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.2.0.tgz",
-      "integrity": "sha512-zHVfv9hPuWxBoGi7ZMmNPaDX0cn3RMQyu0t2pp/WaNIPLDUjHf4H/gLDeA0G8CiiQCDuiOvtPctqIC8UvmF7vw==",
-      "dev": true,
-      "dependencies": {
-        "json2php": "^0.0.7"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
       }
     },
     "node_modules/@wordpress/e2e-test-utils-playwright": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@10up/cypress-wp-utils": "^0.2.0",
         "@10up/eslint-config": "^4.0.0",
+        "@wordpress/dependency-extraction-webpack-plugin": "^6.1.0",
         "@wordpress/env": "^8.9.0",
         "@wordpress/scripts": "^27.8.0",
         "cypress": "^13.3.0",
@@ -4537,15 +4538,16 @@
       }
     },
     "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-5.8.0.tgz",
-      "integrity": "sha512-DdFjCrBkV0maEh1REY8QFtg6rfgGz+qXw8qJ0HxfH+Uees16oCModxBmbgCTC2w3IkMyHP3kEpvRJHHmYRRmWg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.1.0.tgz",
+      "integrity": "sha512-Dodnc0yn6Q7jZW2S5hUFa/3Ls6/OVUp6mXsPr6HvaTZsy9IzrNJJdTiIbk5nNRXDFt7Yv+f8CB/QIdwV0tweag==",
       "dev": true,
       "dependencies": {
         "json2php": "^0.0.7"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       },
       "peerDependencies": {
         "webpack": "^5.0.0"
@@ -4778,6 +4780,21 @@
         "@playwright/test": "^1.43.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/scripts/node_modules/@wordpress/dependency-extraction-webpack-plugin": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-5.9.0.tgz",
+      "integrity": "sha512-hXbCkbG1XES47t7hFSETRrLfaRSPyQPlCnhlCx7FfhYFD0wh1jVArApXX5dD+A6wTrayXX/a16MpfaNqE662XA==",
+      "dev": true,
+      "dependencies": {
+        "json2php": "^0.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
       }
     },
     "node_modules/@wordpress/scripts/node_modules/@wordpress/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@10up/cypress-wp-utils": "^0.2.0",
     "@10up/eslint-config": "^4.0.0",
-    "@wordpress/env": "^8.9.0",
+    "@wordpress/env": "^10.2.0",
     "@wordpress/scripts": "^27.8.0",
     "cypress": "^13.3.0",
     "cypress-mochawesome-reporter": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@10up/cypress-wp-utils": "^0.2.0",
     "@10up/eslint-config": "^4.0.0",
+    "@wordpress/dependency-extraction-webpack-plugin": "^6.1.0",
     "@wordpress/env": "^8.9.0",
     "@wordpress/scripts": "^27.8.0",
     "cypress": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@10up/cypress-wp-utils": "^0.2.0",
     "@10up/eslint-config": "^4.0.0",
     "@wordpress/env": "^10.2.0",
-    "@wordpress/dependency-extraction-webpack-plugin": "^6.1.0",
     "@wordpress/scripts": "^27.8.0",
     "cypress": "^13.3.0",
     "cypress-mochawesome-reporter": "^3.6.0",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,4 +8,5 @@
 	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
 
 	<rule ref="10up-Default" />
+	<exclude-pattern>/build/</exclude-pattern>
 </ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Convert to Blocks ===
 Contributors:      10up, dsawardekar, tlovett1, jeffpaul
 Tags:              block, block migration, gutenberg migration, gutenberg conversion, convert to blocks
-Tested up to:      6.5
+Tested up to:      6.6
 Stable tag:        1.3.0
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const defaultConfig = require('@wordpress/scripts/config/webpack.config');
-const DependencyExtractionWebpackPlugin = require('@wordpress/dependency-extraction-webpack-plugin');
 
 module.exports = {
 	...defaultConfig,
@@ -10,5 +9,4 @@ module.exports = {
 	module: {
 		...defaultConfig.module,
 	},
-	plugins: [new DependencyExtractionWebpackPlugin()],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const defaultConfig = require('@wordpress/scripts/config/webpack.config');
+const DependencyExtractionWebpackPlugin = require('@wordpress/dependency-extraction-webpack-plugin');
 
 module.exports = {
 	...defaultConfig,
@@ -9,4 +10,5 @@ module.exports = {
 	module: {
 		...defaultConfig.module,
 	},
+	plugins: [new DependencyExtractionWebpackPlugin()],
 };


### PR DESCRIPTION
### Description of the Change
This PR bumps the WP tested up to version 6.6, and bumps the WP min to 6.4. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/convert-to-blocks/issues/172

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Bump WordPress "tested up to" version 6.6.
> Changed - Bump WordPress minimum from 6.3 to 6.4.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @sudip-md, @ankitguptaindia 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
