### PR TITLE
upkeep/wp-deploy: Move from `actions/upload-release-asset` to `softprops/action-gh-release`

### DIFF
--- a/.github/workflows/dotorg-push-deploy.yml
+++ b/.github/workflows/dotorg-push-deploy.yml
@@ -32,11 +32,8 @@ jobs:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
 
     - name: Upload release asset
-      uses: actions/upload-release-asset@v1
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ${{github.workspace}}/${{ github.event.repository.name }}.zip
-        asset_name: ${{ github.event.repository.name }}.zip
-        asset_content_type: application/zip
+        files: ${{github.workspace}}/${{ github.event.repository.name }}.zip


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->

`actions/upload-release-asset` has been deprecated and `softprops/action-gh-release` is the recommended replacement.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Verify the ZIP attached in a release.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - Move from `actions/upload-release-asset` to `softprops/action-gh-release` Github action.
