### PR TITLE
Docs: Fix broken link to Block Catalog repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Convert to Blocks is a WordPress plugin that transforms classic editor content to blocks on-the-fly. After installing Gutenberg or upgrading to WordPress 5.0+, your content will be displayed in "Classic Editor Blocks". While these blocks are completely functional and will display fine on the frontend of your website, they do not empower editors to fully make use of the block editing experience. In order to do so, your classic editor posts need to be converted to blocks. This plugin does that for you "on the fly". When an editor goes to edit a classic post, the content will be parsed into blocks. When the editor saves the post, the new structure will be saved into the database. This strategy reduces risk as you are only altering database values for content that needs to be changed.
 
-When combined with the [Block Catalog Plugin](https://github.com/10up-block-catalog/block-catalog), Convert to Blocks can be used to bulk convert only classic editor content to blocks. This is especially useful for sites with a combination of classic and block editor content.
+When combined with the [Block Catalog Plugin](https://github.com/10up/block-catalog), Convert to Blocks can be used to bulk convert only classic editor content to blocks. This is especially useful for sites with a combination of classic and block editor content.
 
 ### Bulk migration of Classic Editor items to the Block Editor
 


### PR DESCRIPTION
## Description of the Change

Fix broken link in readme.

### How to test the Change
See that the link now works 😄 

### Changelog Entry
Fixed: broken link to the Block Catalog plugin in the readme.

### Credits
Props @GaryJones

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
