### PR TITLE
Bump: "Tested up to" WP 6.7

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest', continue: false}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.4', continue: false}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.5', continue: false}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master', continue: true}
     steps:
     - name: Checkout

--- a/convert-to-blocks.php
+++ b/convert-to-blocks.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/convert-to-blocks
  * Description:       Convert classic editor posts to blocks on the fly.
  * Version:           1.3.1
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP:      8.0
  * Author:            10up
  * Author URI:        https://10up.com

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Convert to Blocks ===
 Contributors:      10up, dsawardekar, tlovett1, jeffpaul
 Tags:              block, block migration, gutenberg migration, gutenberg conversion, convert to blocks
-Tested up to:      6.6
+Tested up to:      6.7
 Stable tag:        1.3.1
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
### Description of the Change
Updates WordPress "Tested Up To" version to 6.7.

Closes https://github.com/10up/convert-to-blocks/issues/187

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry

> Changed - Bump WordPress "tested up to" version 6.7.

### Credits
Props @colinswinney 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
