### PR TITLE
Feat: Add plugin page link to settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/), and will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - TBD
+- Add plugin page link to settings page (props [@badasswp](https://github.com/badasswp) via [#195](https://github.com/10up/convert-to-blocks/pull/195)).
 
 ## [1.3.2] - 2025-02-03
 ### Changed

--- a/config.php
+++ b/config.php
@@ -19,6 +19,7 @@ convert_to_blocks_define( 'CONVERT_TO_BLOCKS_DIR', plugin_dir_path( __FILE__ ) )
 convert_to_blocks_define( 'CONVERT_TO_BLOCKS_URL', plugin_dir_url( __FILE__ ) );
 convert_to_blocks_define( 'CONVERT_TO_BLOCKS_SLUG', 'convert-to-blocks' );
 convert_to_blocks_define( 'CONVERT_TO_BLOCKS_DEFAULT_POST_TYPES', [ 'post', 'page' ] );
+convert_to_blocks_define( 'CONVERT_TO_BLOCKS_PLUGIN_BASENAME', plugin_basename( __DIR__ . '/convert-to-blocks.php' ) );
 
 /* Labels */
 

--- a/includes/ConvertToBlocks/Settings.php
+++ b/includes/ConvertToBlocks/Settings.php
@@ -58,6 +58,7 @@ class Settings {
 		add_action( 'admin_init', [ $this, 'register_section' ], 10 );
 		add_action( 'admin_init', [ $this, 'register_fields' ], 20 );
 		add_action( 'admin_notices', [ $this, 'filter_notice' ], 10 );
+		add_filter( 'plugin_action_links', [ $this, 'add_settings_link' ], 10, 2 );
 	}
 
 	/**
@@ -258,6 +259,35 @@ class Settings {
 			</p>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Adds Settings link to the plugin list.
+	 *
+	 * @param array  $links       Array of links.
+	 * @param string $plugin_file Plugin file.
+	 *
+	 * @return array
+	 */
+	public function add_settings_link( $links, $plugin_file ): array {
+		if ( sprintf( '%1$s/%1$s.php', CONVERT_TO_BLOCKS_SLUG ) !== $plugin_file ) {
+			return $links;
+		}
+
+		$settings_link = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url(
+				add_query_arg(
+					[
+						'page' => CONVERT_TO_BLOCKS_SLUG,
+					],
+					admin_url( 'options-general.php' )
+				)
+			),
+			esc_html__( 'Settings', 'convert-to-blocks' )
+		);
+
+		return [ $settings_link, ...$links ];
 	}
 
 }

--- a/includes/ConvertToBlocks/Settings.php
+++ b/includes/ConvertToBlocks/Settings.php
@@ -59,7 +59,7 @@ class Settings {
 		add_action( 'admin_init', [ $this, 'register_section' ], 10 );
 		add_action( 'admin_init', [ $this, 'register_fields' ], 20 );
 		add_action( 'admin_notices', [ $this, 'filter_notice' ], 10 );
-		add_filter( "plugin_action_links_{$plugin_file}", [ $this, 'add_settings_link' ] );
+		add_filter( 'plugin_action_links_' . CONVERT_TO_BLOCKS_PLUGIN_BASENAME, [ $this, 'add_settings_link' ] );
 	}
 
 	/**

--- a/includes/ConvertToBlocks/Settings.php
+++ b/includes/ConvertToBlocks/Settings.php
@@ -266,9 +266,13 @@ class Settings {
 	 * Adds Settings link to the plugin list.
 	 *
 	 * @param array $links Array of links.
-	 * @return array
+	 * @return mixed
 	 */
-	public function add_settings_link( $links ): array {
+	public function add_settings_link( $links ): mixed {
+		if ( ! is_array( $links ) ) {
+			return $links;
+		}
+
 		$settings_link = sprintf(
 			'<a href="%s">%s</a>',
 			esc_url(

--- a/includes/ConvertToBlocks/Settings.php
+++ b/includes/ConvertToBlocks/Settings.php
@@ -53,7 +53,6 @@ class Settings {
 	public function register() {
 		// Configure variables and get post types.
 		$this->init();
-		$plugin_file = sprintf( '%1$s/%1$s.php', CONVERT_TO_BLOCKS_SLUG );
 
 		add_action( 'admin_menu', [ $this, 'add_menu' ] );
 		add_action( 'admin_init', [ $this, 'register_section' ], 10 );

--- a/includes/ConvertToBlocks/Settings.php
+++ b/includes/ConvertToBlocks/Settings.php
@@ -53,12 +53,13 @@ class Settings {
 	public function register() {
 		// Configure variables and get post types.
 		$this->init();
+		$plugin_file = sprintf( '%1$s/%1$s.php', CONVERT_TO_BLOCKS_SLUG );
 
 		add_action( 'admin_menu', [ $this, 'add_menu' ] );
 		add_action( 'admin_init', [ $this, 'register_section' ], 10 );
 		add_action( 'admin_init', [ $this, 'register_fields' ], 20 );
 		add_action( 'admin_notices', [ $this, 'filter_notice' ], 10 );
-		add_filter( 'plugin_action_links', [ $this, 'add_settings_link' ], 10, 2 );
+		add_filter( "plugin_action_links_{$plugin_file}", [ $this, 'add_settings_link' ] );
 	}
 
 	/**
@@ -264,16 +265,10 @@ class Settings {
 	/**
 	 * Adds Settings link to the plugin list.
 	 *
-	 * @param array  $links       Array of links.
-	 * @param string $plugin_file Plugin file.
-	 *
+	 * @param array $links Array of links.
 	 * @return array
 	 */
-	public function add_settings_link( $links, $plugin_file ): array {
-		if ( sprintf( '%1$s/%1$s.php', CONVERT_TO_BLOCKS_SLUG ) !== $plugin_file ) {
-			return $links;
-		}
-
+	public function add_settings_link( $links ): array {
 		$settings_link = sprintf(
 			'<a href="%s">%s</a>',
 			esc_url(


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/10up/convert-to-blocks/issues/186).

### Description of the Change

When viewing the `wp-admin/plugins.php` page, the **Settings** link for the plugin should be easily accessible by a user and when the user clicks on it, they should be directed to the plugin's page `wp-admin/admin.php?page=convert-to-blocks`.

This PR implements this correctly.

Closes #186 

### How to test the Change

- Pull PR to local.
- Build plugin correctly like so: `npm start`.
- Head off to your `plugins.php` page.
- You should now see that there is a **Settings** link that points to the plugin's settings page like so:

<img width="592" alt="Screenshot 2025-03-07 at 02 17 43" src="https://github.com/user-attachments/assets/92ca08d9-7466-4592-a7f0-ac889f8ac15b" />

---

<img width="534" alt="Screenshot 2025-03-07 at 02 19 51" src="https://github.com/user-attachments/assets/8a0abde6-d97b-46ed-8141-f6c2e53072e8" />

### Changelog Entry
- Add plugin page link to settings page (props [@badasswp](https://github.com/badasswp) via [#195](https://github.com/10up/convert-to-blocks/pull/195)).

### Credits
@badasswp

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.