### PR TITLE
Update all actions we use in our workflows to pull from specific pinned commits

### DIFF
--- a/.github/workflows/build-release-zip.yml
+++ b/.github/workflows/build-release-zip.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         env:
           cache-name: cache-node-modules
         with:
@@ -24,7 +24,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
       - name: Setup node version and npm cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -37,4 +37,4 @@ jobs:
         run: npm run build
 
       - name: Generate ZIP file
-        uses: 10up/action-wordpress-plugin-build-zip@stable
+        uses: 10up/action-wordpress-plugin-build-zip@b9e621e1261ccf51592b6f3943e4dc4518fca0d1 # v1.0.2

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -15,7 +15,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-stale: 7
           days-before-close: 7
@@ -33,4 +33,4 @@ jobs:
           close-issue-reason: 'not_planned'
           any-of-labels: 'needs:feedback'
           remove-stale-when-updated: true
-          
+

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,29 +18,38 @@ jobs:
           - {name: 'WP latest', version: 'latest', continue: false}
           - {name: 'WP minimum', version: 'WordPress/WordPress#6.5', continue: false}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master', continue: true}
+
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Install dependencies
       run: npm ci
+
     - name: Composer (optional)
       run: composer install
       continue-on-error: true
-    - uses: actions/setup-node@v4
+
+    - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         node-version-file: '.nvmrc'
+
     - name: Build (optional)
       run: npm ci && npm run build
       continue-on-error: true
+
     - name: Set the core version
       run: ./tests/bin/set-core-version.js ${{ matrix.core.version }}
+
     - name: Set up WP environment
       run: npm run env:start
+
     - name: Test
       run: npm run cypress:run
       continue-on-error: ${{ matrix.core.continue }}
+
     - name: Make artifacts available
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
       if: failure()
       with:
         name: cypress-artifact

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Install dependencies
       run: npm ci

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Dependency Review
         uses: actions/dependency-review-action@72eb03d02c7872a771aacd928f3123ac62ad6d3a # v4.3.3

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v3
+        uses: checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Dependency Review
-        uses: actions/dependency-review-action@v3
+        uses: actions/dependency-review-action@72eb03d02c7872a771aacd928f3123ac62ad6d3a # v4.3.3
         with:
           license-check: true
           vulnerability-check: false

--- a/.github/workflows/dotorg-asset-readme-update.yml
+++ b/.github/workflows/dotorg-asset-readme-update.yml
@@ -9,12 +9,13 @@ jobs:
   trunk:
     name: Push to trunk
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup node version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -25,7 +26,7 @@ jobs:
           npm run build
 
       - name: WordPress.org plugin asset/readme update
-        uses: 10up/action-wordpress-plugin-asset-update@stable
+        uses: 10up/action-wordpress-plugin-asset-update@2480306f6f693672726d08b5917ea114cb2825f7 # v2.2.0
         env:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/dotorg-push-deploy.yml
+++ b/.github/workflows/dotorg-push-deploy.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Setup node version
       uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0

--- a/.github/workflows/dotorg-push-deploy.yml
+++ b/.github/workflows/dotorg-push-deploy.yml
@@ -8,12 +8,13 @@ jobs:
   tag:
     name: New release
     runs-on: ubuntu-latest
+
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Setup node version
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         node-version-file: '.nvmrc'
 
@@ -24,7 +25,7 @@ jobs:
 
     - name: WordPress Plugin Deploy
       id: deploy
-      uses: 10up/action-wordpress-plugin-deploy@stable
+      uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # v2.3.0
       with:
         generate-zip: true
       env:
@@ -32,7 +33,7 @@ jobs:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
 
     - name: Upload release asset
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,33 +13,42 @@ jobs:
   eslint:
     name: eslint
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v3
+    - uses: checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Install node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         node-version-file: '.nvmrc'
+
     - name: npm install
       run: npm install
+
     - name: eslint
-      uses: icrawl/action-eslint@v1
+      uses: icrawl/action-eslint@ff2a58dcbc1aaec51815d58e8bf70962c4f2b557 # v1
       with:
         custom-glob: assets
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   phpcs:
     name: phpcs
     runs-on: ubuntu-latest
+
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Set PHP version
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
       with:
         php-version: '8.0'
         coverage: none
         tools: phpcs
+
     - name: composer install
       run: composer install
+
     - name: PHPCS check
       run: './vendor/bin/phpcs .'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Install node
       uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set PHP version
       uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - uses: getong/mariadb-action@v1.1
+    - uses: getong/mariadb-action@d6d2ec41fd5588f369be4c9398ce77ee725ca9ea # v1.11
 
     - name: Set PHP version
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
       with:
         php-version: '8.0'
         coverage: none

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - uses: getong/mariadb-action@d6d2ec41fd5588f369be4c9398ce77ee725ca9ea # v1.11
 

--- a/.github/workflows/wordpress-version-checker.yml
+++ b/.github/workflows/wordpress-version-checker.yml
@@ -18,6 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: WordPress version checker
-        uses: skaut/wordpress-version-checker@master
+        uses: skaut/wordpress-version-checker@9d247334f5b30202cb9c1f4aee74c52f37399f69 # v2.2.3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description of the Change

In order to help protect against compromised actions, instead of including actions based on their major version (like v4), this PR switches all the actions we use to pull based on the commit hash from the latest release.

While this does impact maintenance a bit going forward, it ensures that we we're always using actions that we (hopefully) trust and if an action gets compromised (which [happens](https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/)) we don't have to worry that we're using a compromised action. This also goes along with what [GitHub suggests](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

### How to test the Change

Ensure all our workflows still run as expected

### Changelog Entry

> Developer - Update all third-party actions our workflows rely on to use versions based on specific commit hashes.

### Credits

Props @dkotter, @jeffpaul 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
