### PR TITLE
Bump WordPress "tested up to" version 6.8

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest', continue: false}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.5', continue: false}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.6', continue: false}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master', continue: true}
 
     steps:

--- a/convert-to-blocks.php
+++ b/convert-to-blocks.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/convert-to-blocks
  * Description:       Convert classic editor posts to blocks on the fly.
  * Version:           1.3.2
- * Requires at least: 6.5
+ * Requires at least: 6.6
  * Requires PHP:      8.0
  * Author:            10up
  * Author URI:        https://10up.com

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Convert to Blocks ===
 Contributors:      10up, dsawardekar, tlovett1, jeffpaul
 Tags:              block, block migration, gutenberg migration, gutenberg conversion, convert to blocks
-Tested up to:      6.7
+Tested up to:      6.8
 Stable tag:        1.3.2
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR bumps the WP tested-up-to 6.8 and the WP min to 6.6.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #198.

### How to test the Change
Already tested via https://github.com/10up/convert-to-blocks/issues/198#issuecomment-2828599817, but let's see that e2e tests pass here as well.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Bump WordPress "tested up to" version 6.8.
> Changed - Bump WordPress minimum supported version to 6.6.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
