### PR TITLE
Fix PHP Notice: Function _load_textdomain_just_in_time was called incorrectly.

### DIFF
--- a/config.php
+++ b/config.php
@@ -20,21 +20,3 @@ convert_to_blocks_define( 'CONVERT_TO_BLOCKS_URL', plugin_dir_url( __FILE__ ) );
 convert_to_blocks_define( 'CONVERT_TO_BLOCKS_SLUG', 'convert-to-blocks' );
 convert_to_blocks_define( 'CONVERT_TO_BLOCKS_DEFAULT_POST_TYPES', [ 'post', 'page' ] );
 convert_to_blocks_define( 'CONVERT_TO_BLOCKS_PLUGIN_BASENAME', plugin_basename( __DIR__ . '/convert-to-blocks.php' ) );
-
-/* Labels */
-
-/* Block Editor text label */
-convert_to_blocks_define( 'SWITCH_TO_BLOCK_EDITOR_LABEL', __( 'Switch to Block Editor', 'convert-to-blocks' ) );
-
-/* Classic Editor text label */
-convert_to_blocks_define( 'SWITCH_TO_CLASSIC_EDITOR_LABEL', __( 'Switch to Classic Editor', 'convert-to-blocks' ) );
-
-/* Add/Edit Labels */
-convert_to_blocks_define( 'EDIT_IN_CLASSIC_EDITOR_LABEL', __( 'Edit (Classic)', 'convert-to-blocks' ) );
-convert_to_blocks_define( 'ADD_NEW_CLASSIC_EDITOR_LABEL', __( 'Add New (Classic)', 'convert-to-blocks' ) );
-convert_to_blocks_define( 'ADD_NEW_BLOCK_EDITOR_LABEL', __( 'Add New', 'convert-to-blocks' ) );
-
-/* Block & Classic Editor Labels */
-convert_to_blocks_define( 'BLOCK_EDITOR_LABEL', __( 'Block Editor', 'convert-to-blocks' ) );
-convert_to_blocks_define( 'CLASSIC_EDITOR_LABEL', __( 'Classic Editor', 'convert-to-blocks' ) );
-convert_to_blocks_define( 'EDITOR_COLUMN_LABEL', __( 'Editor', 'convert-to-blocks' ) );

--- a/includes/ConvertToBlocks/PostTypeColumnSupport.php
+++ b/includes/ConvertToBlocks/PostTypeColumnSupport.php
@@ -101,10 +101,10 @@ class PostTypeColumnSupport {
 		// phpcs:disable
 		if ( $this->is_block_editor_post( $post_id ) ) {
 			$icon  = $this->get_block_editor_column_icon();
-			$title = __( BLOCK_EDITOR_LABEL, 'convert-to-blocks' );
+			$title = __( 'Block Editor', 'convert-to-blocks' );
 		} else {
 			$icon  = $this->get_classic_editor_column_icon();
-			$title = __( CLASSIC_EDITOR_LABEL, 'convert-to-blocks' );
+			$title = __(  'Classic Editor', 'convert-to-blocks' );
 		}
 		// phpcs:enable
 


### PR DESCRIPTION
### Description of the Change
There is a PHP Notices due to i18n functions being called early. 

I've noticed that most of these labels aren't in use, and others are being translated again later (which doesn't seem ideal). Since they aren't being reused, I've deleted all label config defines and translated them when they are being used.

### How to test the Change
Open wp-admin on the latest version of WordPress with WP_DEBUG set to true and your preferred method to look at PHP errors/notices. The notices will be removed with the changes.

### Changelog Entry
> Fixed - i18n functions being called too early, causing PHP Notices.

### Credits
Props @stormrockwell

### Checklist:
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
