### PR TITLE
Ensure our code works on PHP 8.0 and not just 8.1+

### DIFF
--- a/includes/ConvertToBlocks/Settings.php
+++ b/includes/ConvertToBlocks/Settings.php
@@ -272,20 +272,21 @@ class Settings {
 			return $links;
 		}
 
-		$settings_link = sprintf(
-			'<a href="%s">%s</a>',
-			esc_url(
-				add_query_arg(
-					[
-						'page' => CONVERT_TO_BLOCKS_SLUG,
-					],
-					admin_url( 'options-general.php' )
-				)
+		$action_links = [
+			'settings' => sprintf(
+				'<a href="%s">%s</a>',
+				esc_url(
+					add_query_arg(
+						[
+							'page' => CONVERT_TO_BLOCKS_SLUG,
+						],
+						admin_url( 'options-general.php' )
+					)
+				),
+				esc_html__( 'Settings', 'convert-to-blocks' )
 			),
-			esc_html__( 'Settings', 'convert-to-blocks' )
-		);
+		];
 
-		return [ $settings_link, ...$links ];
+		return array_merge( $action_links, $links );
 	}
-
 }


### PR DESCRIPTION
### Description of the Change

As reported on the WordPress.org forum, there is an issue in the latest release where any plugin that comes after Convert to Blocks doesn't show properly in the plugin list.

In that release, we did add code that adds a setting link to this screen (#195) and so I figured that was probably the culprit. Looking at the code for that again, noticed we had some code that only works on PHP 8.1+, so sites running PHP 8.0 (which is our minimum) will run into an error on the plugin screen. This PR fixes that

### How to test the Change

1. Install the latest version of Convert to Blocks within an environment running PHP 8.0
2. Go to the plugin list screen and notice a PHP error will be thrown
3. Update to PHP 8.2+ and notice the error goes away
4. Checkout this PR and test again on PHP 8.0
5. Notice no error is thrown

### Changelog Entry

> Fixed - Ensure no PHP error is thrown on the plugin list screen when running PHP 8.0

### Credits

Props @dkotter, [dinhac](https://wordpress.org/support/users/dinhac/)

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
