### PR TITLE
Indicate support for WordPress 7.0 (trunk).

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Convert to Blocks ===
 Contributors:      10up, dsawardekar, tlovett1, jeffpaul
 Tags:              block, block migration, gutenberg migration, gutenberg conversion, convert to blocks
-Tested up to:      6.9
+Tested up to:      7.0
 Stable tag:        1.3.4
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
### Description of the Change

Update readme to indicate support for WordPress 7.0.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #231 
Cherry-picks https://github.com/10up/convert-to-blocks/pull/243 to trunk.

### How to test the Change

See testing steps taken in https://github.com/10up/convert-to-blocks/issues/231#issuecomment-4426907596

### Changelog Entry
> Changed - Indicate support for WordPress 7.0.

### Credits
Props @peterwilsoncc, @dkotter 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
