### PR TITLE
WP Compatibility Check Against WP Core 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Convert to Blocks ===
 Contributors:      10up, dsawardekar, tlovett1, jeffpaul
 Tags:              block, block migration, gutenberg migration, gutenberg conversion, convert to blocks
-Tested up to:      7.0
+Tested up to:      7.1
 Stable tag:        1.3.4
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
### Description of the Change
Tested compatibility against WP Core 7.1 RC1. The plugin functions as expected with the 7.1 RC1

Closes #258 

### How to test the Change

1. Update WP Core version to 7.1 RC1 using any methods described [here](https://wordpress.org/news/2026/08/wordpress-7-1-release-candidate-1/)
2. Create a post with classic editor and test many variants (title, image, links, etc)
3. Check basic commands do not throw an error
4. Convert post using the commands provided by the plugin.
6. Navigate to any screens and there should be no warnings and/or errors related to the plugin
7. Posts converted correctly. 

### Changelog Entry
> Developer - Bumped up Tested up to from 7.0 to 7.1

### Credits
Props @oscarssanchezz 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
